### PR TITLE
Use RecordDataFormatter.ini instead of hard coded function mapping

### DIFF
--- a/config/vufind/RecordDataFormatter.ini
+++ b/config/vufind/RecordDataFormatter.ini
@@ -12,6 +12,13 @@
 ; One can also add any other option. See https://vufind.org/wiki/development:architecture:record_data_formatter
 ; for all available options.
 
+; Mapping for the factory functions
+[Defaults_Function_Mapping]
+collection-info = getDefaultCollectionInfoSpecs
+collection-record = getDefaultCollectionRecordSpecs
+core = getDefaultCoreSpecs
+description = getDefaultDescriptionSpecs
+
 ; In this section, extra fields can be added that are not already included in the RecordDataFormatterFactory or
 ; RecordDataFormatter\Specs\DefaultRecord plugin.
 ; Add the name of the field to the respective array. The options of the field need to be set in

--- a/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/VuFind/src/VuFind/View/Helper/Root/RecordDataFormatterFactory.php
@@ -105,12 +105,10 @@ class RecordDataFormatterFactory implements FactoryInterface
         // for legacy backward compatibility check if getDefault*Specs methods got overridden.
         $this->schemaOrgHelper = $container->get('ViewHelperManager')->get('schemaOrg');
         $this->defaultRecordSpec = $specPluginManager->get(DefaultRecordSpec::class);
-        $methodMapping = [
-            'collection-info' => 'getDefaultCollectionInfoSpecs',
-            'collection-record' => 'getDefaultCollectionRecordSpecs',
-            'core' => 'getDefaultCoreSpecs',
-            'description' => 'getDefaultDescriptionSpecs',
-        ];
+        $methodMapping =  $container
+                            ->get(\VuFind\Config\PluginManager::class)
+                            ->get('RecordDataFormatter')
+                            ->Defaults_Function_Mapping ?? [];
         $showDeprecationWarning = false;
         foreach ($methodMapping as $context => $method) {
             $reflector = new \ReflectionMethod($this, $method);

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/RecordDataFormatterTest.php
@@ -213,6 +213,12 @@ class RecordDataFormatterTest extends \PHPUnit\Framework\TestCase
         $factory = new RecordDataFormatterFactory();
         $container = new \VuFindTest\Container\MockContainer($this);
         $recordDataFormatterConfig = array_merge($additionalConfig, [
+            'Defaults_Function_Mapping' => [
+                'collection-info' => 'getDefaultCollectionInfoSpecs',
+                'collection-record' => 'getDefaultCollectionRecordSpecs',
+                'core' => 'getDefaultCoreSpecs',
+                'description' => 'getDefaultDescriptionSpecs',
+            ],
             'Defaults' => [
                 'core' => ['Extra'],
             ],


### PR DESCRIPTION
Prevent use of hard coded mapping in `RecordDataFormatterFactory.php`
Benefits, when someone wants to customize their instance and add for example `toc[] = Summary` to their displayed  fields (our case) no need to override any function but just add the corresponding function mapping